### PR TITLE
Fix job url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # InfraOps Engineer Hiring Project
 
-Hello! This is a hiring project for our [InfraOps Engineer position](https://fly.io/jobs/infrastructure-ops-engineering/). If you apply, we’ll ask you to do this project so we can see how you work through a contrived (yet shockingly accurate) example of the type of things you’d do at Fly.io. Checkout the job post for the nitty gritty.
+Hello! This is a hiring project for our [Infrastructure Engineering position](https://fly.io/jobs/infrastructure-engineering/). If you apply, we’ll ask you to do this project so we can see how you work through a contrived (yet shockingly accurate) example of the type of things you’d do at Fly.io. Checkout the job post for the nitty gritty.
 
 There are two parts to this challenge. One is debugging a network problem between two VMs, the other is debugging and writing a small script to fix a storage problem.
 


### PR DESCRIPTION
The README is linking to a closed job requisition page. this just updates it to the current one.